### PR TITLE
Support UTF-16 encoded FStrings

### DIFF
--- a/UnrealEngine.Gvas/BinaryReaderEx.cs
+++ b/UnrealEngine.Gvas/BinaryReaderEx.cs
@@ -8,9 +8,11 @@ public static class BinaryReaderEx
     public static string? ReadFString(this BinaryReader reader)
     {
         int length = reader.ReadInt32();
-        if (length is > 512 or < 0)
+        if (length is > 512 or < -512)
             throw new SaveGameException($"Sanity check failed: FString length is {length}");
 
+        if (length is < 0)
+            return Encoding.Unicode.GetString(reader.ReadBytes(length * -2)).TrimEnd('\0');
         return Encoding.ASCII.GetString(reader.ReadBytes(length)).TrimEnd('\0');
     }
 
@@ -18,9 +20,20 @@ public static class BinaryReaderEx
     {
         if (str is {Length: > 0})
         {
-            writer.Write(str!.Length + 1);
-            writer.Write(str.ToCharArray());
-            writer.Write((byte) 0);
+            if (Encoding.UTF8.GetByteCount(str) == str.Length)
+            {
+                // safe to use 7-bit ASCII encoding
+                writer.Write(str!.Length + 1);
+                writer.Write(str.ToCharArray());
+                writer.Write((byte) 0);
+            }
+            else
+            {
+                // use UTF-16 LE encoding
+                writer.Write(-1 - Encoding.Unicode.GetByteCount(str)/2);
+                writer.Write(Encoding.Unicode.GetBytes(str));
+                writer.Write((short) 0);
+            }
         }
         else
         {


### PR DESCRIPTION
First off, thanks for sharing this code! While it worked perfectly for the game I tried (World of Cube), to show my appreciation I spent a little time on the open compatibility issues. This series of pull requests allows SavToXml to successfully convert all three save files in the open issues, hopefully without breaking any currently-working examples.

In BreathEdge (#1) and Mortal Shell (#2), some FStrings are encoded as UTF-16, identified by a negative length (of characters, not bytes) in the prefix. This adds Read and (untested) Write support.