### PR TITLE
Handle arrays of floats

### DIFF
--- a/UnrealEngine.Gvas/FProperties/FArrayProperty.cs
+++ b/UnrealEngine.Gvas/FProperties/FArrayProperty.cs
@@ -79,6 +79,15 @@ public class FArrayProperty : FProperty
                 Elements.Add(elementInstance);
             }
         }
+        else if (ElementType == "FloatProperty")
+        {
+            for (int i = 0; i < elementCount; i++)
+            {
+                var elementInstance = new FFloatProperty();
+                elementInstance.Read(reader, propertyName, 0, true);
+                Elements.Add(elementInstance);
+            }
+        }
         else
             throw new SaveGameException($"Unsupported {nameof(FArrayProperty)} type: '{ElementType}'");
     }
@@ -96,7 +105,7 @@ public class FArrayProperty : FProperty
             foreach (var property in Elements)
                 property.WriteTo(writer, i++ == 0);
         } 
-        else if (ElementType is "IntProperty" or "BoolProperty" or "ByteProperty" or "NameProperty" or "StrProperty")
+        else if (ElementType is "IntProperty" or "BoolProperty" or "ByteProperty" or "NameProperty" or "StrProperty" or "FloatProperty")
         {
             foreach (var property in Elements)
                 property.WriteTo(writer, false);


### PR DESCRIPTION
This adds the FFloatProperty type to FArrayProperty. Arrays of floats are seen in BreathEdge (#1).