### PR TITLE
Handle FStructProperty instances with no field data

### DIFF
--- a/UnrealEngine.Gvas/FProperties/FStructProperty.cs
+++ b/UnrealEngine.Gvas/FProperties/FStructProperty.cs
@@ -16,6 +16,8 @@ public class FStructProperty : FProperty
             TypeName = reader.ReadFString();
             structureGuid = new Guid(reader.ReadBytes(16));
             reader.ReadBytes(1);
+            if (fieldLength == 0)
+              return;
         }
 
         if (TypeName == "Vector")


### PR DESCRIPTION
This ends an FStructProperty when the field length is explicitly given as zero in the header. BreathEdge (#1) has several of these, with a custom type and no data encoded in the save file. With this change, the stack no longer overflows on the sample file.