### PR TITLE
Write Quat struct type

### DIFF
--- a/UnrealEngine.Gvas/FProperties/FStructProperty.cs
+++ b/UnrealEngine.Gvas/FProperties/FStructProperty.cs
@@ -73,11 +73,12 @@ public class FStructProperty : FProperty
             writer.Write((Fields["Yaw"] as FFloatProperty)!.Value);
             writer.Write((Fields["Roll"] as FFloatProperty)!.Value);
         }
-        else if (TypeName == "Vector")
+        else if (TypeName == "Quat")
         {
             writer.Write((Fields["X"] as FFloatProperty)!.Value);
             writer.Write((Fields["Y"] as FFloatProperty)!.Value);
             writer.Write((Fields["Z"] as FFloatProperty)!.Value);
+            writer.Write((Fields["W"] as FFloatProperty)!.Value);
         }
         else if (TypeName == "DateTime")
             writer.Write((Fields["Ticks"] as FInt64Property)!.Value);


### PR DESCRIPTION
While working on other changes, I noticed a copy-paste error in the Write routine: there were two checks for "Vector" and none for "Quat". This aligns the Write code with the Read code.