### PR TITLE
Improve compatibility of FTextProperty parser

### DIFF
--- a/UnrealEngine.Gvas/FProperties/FTextProperty.cs
+++ b/UnrealEngine.Gvas/FProperties/FTextProperty.cs
@@ -1,29 +1,58 @@
+using System.Xml.Linq;
 namespace UnrealEngine.Gvas.FProperties;
 
 [OptionalGuid]
 public class FTextProperty : FProperty
 {
+    public string? Owner { get; set; }
+    public string? Identifier { get; set; }
     public string? Value { get; set; }
     public int Unknown1 { get; set; }
-    public byte Unknown2 { get; set; }
-    public byte[]? Unknown3 { get; set; }
+    public byte Flags { get; set; }
     
     internal override void Read(BinaryReader reader, string? propertyName, long fieldLength, bool bodyOnly = false)
     {
         long startPos = reader.BaseStream.Position;
         Unknown1 = reader.ReadInt32();
-        Unknown2 = reader.ReadByte();
-        if (Unknown1 != 0)
+        Flags = reader.ReadByte();
+        if (fieldLength == 5)
         {
-            reader.ReadInt32();
+          if (Flags != 255)
+          {
+            throw new NotImplementedException();
+          }
+          return;
+        }
+        Owner = reader.ReadFString();
+        if (Flags == 255)
+        {
+          // no extra fields
+        }
+        else if (Flags == 11)
+        {
+            Identifier = reader.ReadFString();
+        }
+        else if (Flags == 0)
+        {
+            Identifier = reader.ReadFString();
             Value = reader.ReadFString();
-            int bytesLeft = (int) (fieldLength - (reader.BaseStream.Position - startPos));
-            Unknown3 = reader.ReadBytes(bytesLeft);
+        }
+        else
+        {
+          throw new NotImplementedException();
         }
     }
 
     protected override IEnumerable<object> SerializeContent()
     {
-        throw new NotImplementedException();
+        yield return Value ?? string.Empty;
+    }
+
+    protected override void ModifyXmlNode(XElement element)
+    {
+        if (Owner is {Length: > 0})
+            element.SetAttributeValue("Owner", Owner);
+        if (Identifier is {Length: > 0})
+            element.SetAttributeValue("Identifier", Identifier);
     }
 }


### PR DESCRIPTION
This extends the FTextProperty class to parse all instances in the BreathEdge (#1) and Mortal Shell (#3) examples without crashing, and also expose more of the data in XML output. The field names "Owner" and "Flags" come from likely metadata candidates mentioned in UE API documentation. The "Identifier" field was named because looks like a GUID in many cases.