### PR TITLE
Fix index of optional second argument

### DIFF
--- a/SavToXml/Program.cs
+++ b/SavToXml/Program.cs
@@ -21,7 +21,7 @@ public static class Program
 
         string targetFile = Path.Combine(Path.GetDirectoryName(sourceFile)!, Path.GetFileNameWithoutExtension(sourceFile) + ".xml");
         if (args.Length >= 2)
-            targetFile = args[2];
+            targetFile = args[1];
 
         var saveData = SaveGameFile.LoadFrom(sourceFile);
         File.WriteAllText(targetFile, saveData.Serialize().ToString());


### PR DESCRIPTION
My final contribution of the day is a small fix to the SavToXml command-line parsing. It fixes an off-by-one error which generates an out-of-bounds exception when the optional destination-file argument is used.

Thank you again for all your work producing this and sharing it with the public. I understand your lack of maintenance time (my own projects often share the same fate), so please don't feel any pressure to act on these PRs. I had a blast building on your foundation!